### PR TITLE
Add code for cell_gradient_coefs_{xy} expected by RRTMGP

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -484,6 +484,10 @@
 			<var name="deriv_two"/>
 			<var name="defc_a"/>
 			<var name="defc_b"/>
+#ifdef MPAS_CAM_DYCORE
+			<var name="cell_gradient_coef_x"/>
+			<var name="cell_gradient_coef_y"/>
+#endif
 			<var name="coeffs_reconstruct"/>
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
@@ -621,6 +625,10 @@
 			<var name="deriv_two"/>
 			<var name="defc_a"/>
 			<var name="defc_b"/>
+#ifdef MPAS_CAM_DYCORE
+			<var name="cell_gradient_coef_x"/>
+			<var name="cell_gradient_coef_y"/>
+#endif
 			<var name="coeffs_reconstruct"/>
 			<var name="east"/>
 			<var name="north"/>
@@ -1409,6 +1417,14 @@
 
                 <var name="defc_b" type="real" dimensions="maxEdges nCells" units="unitless"
                      description="Coefficients for computing the diagonal components of the horizontal deformation"/>
+
+#ifdef MPAS_CAM_DYCORE
+                <var name="cell_gradient_coef_x" type="real" dimensions="maxEdges nCells" units="m^-1"
+                     description="Coefficients for computing the x (zonal) derivative of a cell-centered variable"/>
+
+                <var name="cell_gradient_coef_y" type="real" dimensions="maxEdges nCells" units="m^-1"
+                     description="Coefficients for computing the y (meridional) derivative of a cell-centered variable"/>
+#endif
 
                 <!-- Arrays required for reconstruction of velocity field -->
                 <var name="coeffs_reconstruct" type="real" dimensions="R3 maxEdges nCells" units="unitless"

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -412,6 +412,8 @@
                         <var name="advCells" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="defc_a" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="defc_b" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
+                        <var name="cell_gradient_coef_x" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
+                        <var name="cell_gradient_coef_y" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="coeffs_reconstruct" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="cf1" packages="met_stage_in"/>
                         <var name="cf2" packages="met_stage_in"/>
@@ -510,6 +512,8 @@
                         <var name="advCells"/>
                         <var name="defc_a"/>
                         <var name="defc_b"/>
+                        <var name="cell_gradient_coef_x"/>
+                        <var name="cell_gradient_coef_y"/>
                         <var name="coeffs_reconstruct"/>
                         <var name="cf1" packages="vertical_stage_out;met_stage_out"/>
                         <var name="cf2" packages="vertical_stage_out;met_stage_out"/>
@@ -866,6 +870,12 @@
 
                 <var name="defc_b" type="real" dimensions="maxEdges nCells" units="unitless"
                      description="Coefficients for computing the diagonal components of the horizontal deformation"/>
+
+                <var name="cell_gradient_coef_x" type="real" dimensions="maxEdges nCells" units="m^-1"
+                     description="Coefficients for computing the x (zonal) derivative of a cell-centered variable"/>
+
+                <var name="cell_gradient_coef_y" type="real" dimensions="maxEdges nCells" units="m^-1"
+                     description="Coefficients for computing the y (meridional) derivative of a cell-centered variable"/>
 
                 <!-- arrays required for reconstruction of velocity field -->
                 <var name="coeffs_reconstruct" type="real" dimensions="R3 maxEdges nCells" units="unitless"

--- a/src/core_init_atmosphere/mpas_atm_advection.F
+++ b/src/core_init_atmosphere/mpas_atm_advection.F
@@ -757,6 +757,7 @@ module atm_advection
 !  local variables
 
       real (kind=RKIND), dimension(:,:), pointer :: defc_a, defc_b
+      real (kind=RKIND), dimension(:,:), pointer :: cell_gradient_coef_x, cell_gradient_coef_y
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, cellsOnCell, verticesOnCell
       integer, dimension(:), pointer :: nEdgesOnCell
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
@@ -777,11 +778,13 @@ module atm_advection
 
       integer :: iv
       logical :: do_the_cell
-      real (kind=RKIND) :: area_cell, sint2, cost2, sint_cost, area_cellt
+      real (kind=RKIND) :: area_cell, sint2, cost2, sint_cost, dx, dy
 
 
       call mpas_pool_get_array(mesh, 'defc_a', defc_a)
       call mpas_pool_get_array(mesh, 'defc_b', defc_b)
+      call mpas_pool_get_array(mesh, 'cell_gradient_coef_x', cell_gradient_coef_x)
+      call mpas_pool_get_array(mesh, 'cell_gradient_coef_y', cell_gradient_coef_y)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(mesh, 'edgesOnCell', edgesOnCell)
@@ -796,6 +799,9 @@ module atm_advection
 
       defc_a(:,:) = 0.
       defc_b(:,:) = 0.
+
+      cell_gradient_coef_x(:,:) = 0.
+      cell_gradient_coef_y(:,:) = 0.
 
       pii = 2.*asin(1.0)
 
@@ -817,14 +823,16 @@ module atm_advection
 
          if (.not. do_the_cell) cycle
 
+         !  compute poynomial fit for this cell if all needed neighbors exist
 
-!  compute poynomial fit for this cell if all needed neighbors exist
          if (on_a_sphere) then
+
+            ! xc holds the center point and the vertex points of the cell,
+            ! normalized to a sphere or radius 1.
 
             xc(1) = xCell(iCell)/sphere_radius
             yc(1) = yCell(iCell)/sphere_radius
             zc(1) = zCell(iCell)/sphere_radius
-
 
             do i=2,n
                iv = verticesOnCell(i-1,iCell)
@@ -842,14 +850,22 @@ module atm_advection
             if (zc(1) == 1.0) then
                theta_abs(iCell) = pii/2.
             else
+               ! theta_abs is the angle to the first vertex from the center, normalized so that
+               ! an eastward pointing vector has a angle of 0.
                theta_abs(iCell) =  pii/2. - sphere_angle( xc(1), yc(1), zc(1),  &
                                                           xc(2), yc(2), zc(2),  &
                                                           0.0_RKIND, 0.0_RKIND, 1.0_RKIND ) 
             end if
 
+            ! here we are constructing the tangent-plane cell.
+            ! thetat is the angle in the (x,y) tangent-plane coordinate from
+            ! the cell center to each vertex, normalized so that an
+            ! eastward pointing vector has a angle of 0.
 
-! angles from cell center to neighbor centers (thetav)
+            ! dl_sphere is the spherical distance from the cell center
+            ! to the sphere vertex points for the cell.
 
+            thetat(1) = theta_abs(iCell)
             do i=1,n-1
    
                ip2 = i+2
@@ -858,22 +874,13 @@ module atm_advection
                thetav(i) = sphere_angle( xc(1),   yc(1),   zc(1),    &
                                          xc(i+1), yc(i+1), zc(i+1),  &
                                          xc(ip2), yc(ip2), zc(ip2)   )
-
                dl_sphere(i) = sphere_radius*arc_length( xc(1),   yc(1),   zc(1),  &
-                                                             xc(i+1), yc(i+1), zc(i+1) )
+                                                        xc(i+1), yc(i+1), zc(i+1) )
+               if(i.gt.1) thetat(i) = thetat(i-1)+thetav(i-1)
             end do
 
-            length_scale = 1.
-            do i=1,n-1
-               dl_sphere(i) = dl_sphere(i)/length_scale
-            end do
+            ! xp and yp are the tangent-plane vertex points with the cell center at (0,0)
 
-            thetat(1) = 0.  !  this defines the x direction, cell center 1 -> 
-!            thetat(1) = theta_abs(iCell)  !  this defines the x direction, longitude line
-            do i=2,n-1
-               thetat(i) = thetat(i-1) + thetav(i-1)
-            end do
-   
             do i=1,n-1
                xp(i) = cos(thetat(i)) * dl_sphere(i)
                yp(i) = sin(thetat(i)) * dl_sphere(i)
@@ -894,27 +901,20 @@ module atm_advection
 
          end if
 
-!         thetat(1) = 0.
-         thetat(1) = theta_abs(iCell)
-         do i=2,n-1
-            ip1 = i+1
-            if (ip1 == n) ip1 = 1
-            thetat(i) = plane_angle( 0.0_RKIND, 0.0_RKIND, 0.0_RKIND,  &
-                                     xp(i)-xp(i-1), yp(i)-yp(i-1), 0.0_RKIND,  &
-                                     xp(ip1)-xp(i), yp(ip1)-yp(i), 0.0_RKIND,  &
-                                     0.0_RKIND, 0.0_RKIND, 1.0_RKIND)
-            thetat(i) = thetat(i) + thetat(i-1)
-         end do
+         ! (1) compute cell area on the tangent plane used in the integrals
+         ! (2) compute angle of cell edge normal vector.  here we are repurposing thetat
 
          area_cell = 0.
-         area_cellt = 0.
          do i=1,n-1
             ip1 = i+1
             if (ip1 == n) ip1 = 1
-            dl = sqrt((xp(ip1)-xp(i))**2 + (yp(ip1)-yp(i))**2)
+            dx = xp(ip1)-xp(i)
+            dy = yp(ip1)-yp(i)
             area_cell = area_cell + 0.25*(xp(i)+xp(ip1))*(yp(ip1)-yp(i)) - 0.25*(yp(i)+yp(ip1))*(xp(ip1)-xp(i))
-            area_cellt = area_cellt + (0.25*(xp(i)+xp(ip1))*cos(thetat(i)) + 0.25*(yp(i)+yp(ip1))*sin(thetat(i)))*dl
+            thetat(i) = atan2(dy,dx)-pii/2.
          end do
+
+         ! coefficients - see documentation for the formulas.
 
          do i=1,n-1
             ip1 = i+1
@@ -925,6 +925,8 @@ module atm_advection
             sint_cost = sin(thetat(i))*cos(thetat(i))
             defc_a(i,iCell) = dl*(cost2 - sint2)/area_cell
             defc_b(i,iCell) = dl*2.*sint_cost/area_cell
+            cell_gradient_coef_x(i,iCell) = dl*cos(thetat(i))/area_cell
+            cell_gradient_coef_y(i,iCell) = dl*sin(thetat(i))/area_cell
             if (cellsOnEdge(1,EdgesOnCell(i,iCell)) /= iCell) then
                defc_a(i,iCell) = - defc_a(i,iCell)
                defc_b(i,iCell) = - defc_b(i,iCell)
@@ -936,4 +938,4 @@ module atm_advection
 
    end subroutine atm_initialize_deformation_weights
 
-end module atm_advection
+ end module atm_advection

--- a/src/external/Makefile
+++ b/src/external/Makefile
@@ -6,7 +6,7 @@ esmf_time:
 	( cd esmf_time_f90; $(MAKE) FC="$(FC)" FFLAGS="$(FFLAGS)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS) -DHIDE_MPI" GEN_F90=$(GEN_F90) )
 
 ezxml-lib:
-	( cd ezxml; $(MAKE) )
+	( cd ezxml; $(MAKE) OBJFILE="ezxml.o" )
 
 clean:
 	( cd esmf_time_f90; $(MAKE) clean )


### PR DESCRIPTION
This PR incorporates a feature from the upstream v8.0.0 MPAS-Model code that is expected by the RRTMGP physics in CAM.

A fix is also included to allow standalone versions of this code to correctly compile (the "revert" commit).