### PR TITLE
Workaround for reading block decomposition files with OpenMPI v5.x

### DIFF
--- a/src/framework/mpas_block_decomp.F
+++ b/src/framework/mpas_block_decomp.F
@@ -63,7 +63,8 @@ module mpas_block_decomp
       character (len=*), intent(in) :: blockFilePrefix, & !< Input: File prefix for block decomposition
                                        procFilePrefix !< Input: File prefix for processor decomposition
 
-      integer, dimension(:), pointer :: global_list
+      integer, dimension(:), allocatable, target :: global_list
+      integer, dimension(:), pointer :: global_list_ptr
       integer, dimension(:), pointer :: global_start
 
       integer, dimension(:), allocatable :: local_block_list
@@ -93,7 +94,8 @@ module mpas_block_decomp
         allocate(local_nvertices(dminfo % nprocs))
         allocate(global_start(dminfo % nprocs))
         allocate(global_list(partial_global_graph_info % nVerticesTotal))
-  
+        global_list_ptr => global_list
+
         if (dminfo % my_proc_id == IO_NODE) then
   
            iunit = 50 + dminfo % my_proc_id
@@ -169,7 +171,7 @@ module mpas_block_decomp
            allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
 
            call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_cell_list)
+                                   global_start, local_nvertices, global_list_ptr, local_cell_list)
 
            ! Reset global start for second read of global_block_list
            global_start(1) = 1
@@ -193,7 +195,7 @@ module mpas_block_decomp
            end do
 
            call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_block_list)
+                                   global_start, local_nvertices, global_list_ptr, local_block_list)
 
            close(unit=iunit)
 
@@ -204,10 +206,10 @@ module mpas_block_decomp
            allocate(local_block_list(local_nvertices(dminfo % my_proc_id + 1)))
   
            call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_cell_list)
+                                   global_start, local_nvertices, global_list_ptr, local_cell_list)
 
            call mpas_dmpar_scatter_ints(dminfo, dminfo % nprocs, local_nvertices(dminfo % my_proc_id + 1), &
-                                   global_start, local_nvertices, global_list, local_block_list)
+                                   global_start, local_nvertices, global_list_ptr, local_block_list)
         end if
 
         if(blocks_per_proc == 0) then


### PR DESCRIPTION
This PR adds a workaround for problems encountered on systems using OpenMPI v5.x (observed with 5.0.7). The inlist argument to mpas_dmpar_scatter_ints seems to be affected by the MPI_ScatterV call, which then causes run-time fails in mpas_block_decomp_cells_for_proc when re-reading the block decomposition file. Making global_list an allocatable, associating a pointer with it, and using that pointer as the inlist argument to mpas_dmpar_scatter_ints seems to resolve the issue.

NOTE: So this PR can be applied broadly it is based on a very, very old commit. I think around v4.0, at least as old as the v6.0 tag.